### PR TITLE
Change clangd handler from on_attach to on_init

### DIFF
--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -32,18 +32,15 @@ return {
         -- fix clangd item
         local function clangd_fix_item(item)
             if item.kind == vim.lsp.protocol.CompletionItemKind.Snippet then
-                local index = item.textEdit.newText:find('{\n\t')
-                if index == nil then
-                    local newText = item.textEdit.newText:gsub('{\n', '{\n\t')
-                    item.textEdit.newText = newText
-                end
+                local new_text = item.textEdit.newText:gsub('{\n', '{\n\t')
+                item.textEdit.newText = new_text
             end
         end
 
         -- clangd
         lspconfig.clangd.setup {
             capabilities = capabilities,
-            on_attach = function(client)
+            on_init = function(client)
                 local orig_rpc_request = client.rpc.request
                 function client.rpc.request(method, params, handler, ...)
                     local orig_handler = handler


### PR DESCRIPTION
This fixes an issue we previously had, where it would go over the same snippet multiple times.
Due to this we had to check if the snippet already contains `{\n\t`, to determine if we should perform a substitution on it. Using `on_init` instead we have circumvented this issue entirely and the `:find` operation is no longer necessary.