### PR TITLE
Create alias for vim.keymap.set

### DIFF
--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -19,8 +19,9 @@ return {
             group = vim.api.nvim_create_augroup('lsp_attach', {}),
             callback = function(ev)
                 local opts = { buffer = ev.buf }
-                vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts)
-                vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, opts)
+                local bind = vim.keymap.set
+                bind('n', '<leader>rn', vim.lsp.buf.rename, opts)
+                bind('n', '<leader>ca', vim.lsp.buf.code_action, opts)
             end,
         })
 


### PR DESCRIPTION
Doing everything for the 80 character line limit. Also typing `bind` is way more ergonomic when creating new keybindings.