### PR TITLE
Update telescope ignore pattern

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,13 +1,13 @@
 {
-  "LuaSnip": { "branch": "master", "commit": "2dbef19461198630b3d7c39f414d09fb07d1fdd2" },
+  "LuaSnip": { "branch": "master", "commit": "f3b3d3446bcbfa62d638b1903ff00a78b2b730a1" },
   "cmp-nvim-lsp": { "branch": "main", "commit": "5af77f54de1b16c34b23cba810150689a3a90312" },
   "cmp_luasnip": { "branch": "master", "commit": "05a9ab28b53f71d1aece421ef32fee2cb857a843" },
   "gruvbox.nvim": { "branch": "main", "commit": "6e4027ae957cddf7b193adfaec4a8f9e03b4555f" },
   "lazy.nvim": { "branch": "main", "commit": "aedcd79811d491b60d0a6577a9c1701063c2a609" },
-  "nvim-autopairs": { "branch": "master", "commit": "096d0baecc34f6c5d8a6dd25851e9d5ad338209b" },
+  "nvim-autopairs": { "branch": "master", "commit": "90f824d37c0cb079d2764927e73af77faa9ba0ef" },
   "nvim-cmp": { "branch": "main", "commit": "04e0ca376d6abdbfc8b52180f8ea236cbfddf782" },
-  "nvim-lspconfig": { "branch": "master", "commit": "f12f1b9e877b1e6e2ef7eae1a524d8253af4243d" },
-  "nvim-treesitter": { "branch": "master", "commit": "3dbea103d83366d4aa312e065812be19f4f16fd6" },
+  "nvim-lspconfig": { "branch": "master", "commit": "6b9f4bbe0aa1f351fd4845dc5fd4f3450b010f88" },
+  "nvim-treesitter": { "branch": "master", "commit": "1398b1ba4619cef240abd496b500b95819c8c496" },
   "plenary.nvim": { "branch": "master", "commit": "4f71c0c4a196ceb656c824a70792f3df3ce6bb6d" },
   "telescope.nvim": { "branch": "master", "commit": "7011eaae0ac1afe036e30c95cf80200b8dc3f21a" }
 }

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -30,7 +30,7 @@ return {
                         ["<esc>"] = "close"
                     }
                 },
-                file_ignore_patterns = { "build/", ".git/" }
+                file_ignore_patterns = { ".git/" }
             }
         }
     },


### PR DESCRIPTION
`build/` should be ignored using a `.gitignore` file inside of a git directory. This is not the responsibility of the neovim config. Other languages like Rust provide simple means to set up a new project, e.g. using `cargo new`. Creating a C/C++ project is a bit cumbersome in comparison. Maybe we should create something like a [GitHub template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository) for C/C++ projects?