### PR TITLE
Add telescope shortcuts for git branches.

### DIFF
--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -5,6 +5,12 @@ return {
         dependencies = { "nvim-lua/plenary.nvim" },
         keys = {
             {
+                "<leader>b",
+                function()
+                    require("telescope.builtin").git_branches()
+                end,
+            },
+            {
                 "<leader>e",
                 function()
                     require("telescope.builtin").buffers()


### PR DESCRIPTION
Adds the telescope shortcut `<leader> b` which shows all branches.