### PR TITLE
Add fugitive shortcut to show git log

### DIFF
--- a/lua/plugins/fugitive.lua
+++ b/lua/plugins/fugitive.lua
@@ -23,7 +23,14 @@ return {
                 function()
                     vim.cmd("0Git")
                 end
-            }
+            },
+            -- logging
+            {
+                "<leader>l",
+                function()
+                    vim.cmd.Git("log")
+                end
+            },
         }
     }
 }


### PR DESCRIPTION
**Changes**
- Add `<leader>l` shortcut which shows the git log

This will be useful for when we want to do an interactive rebase. 
Now we can just hit `<leader>l`, hover over a commit hash and press `ri`,  
to perform an interactive rebase.