### PR TITLE
Add `vim.lsp.buf.hover` shortcut for compatibility

### DIFF
--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -19,6 +19,7 @@ return {
             callback = function(ev)
                 local opts = { buffer = ev.buf }
                 local bind = vim.keymap.set
+                bind('n', 'K', vim.lsp.buf.hover, opts)
                 bind("n", "<leader>rn", vim.lsp.buf.rename, opts)
                 bind("n", "<leader>ca", vim.lsp.buf.code_action, opts)
             end,


### PR DESCRIPTION
Slower rolling distributions like Ubuntu might not have nvim 0.10 yet.