### PR TITLE
Automatically create `~/.clang-format` file

### DIFF
--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -1,3 +1,10 @@
+-- create clang-format file
+local file = vim.fn.expand("~/.clang-format")
+if not vim.uv.fs_stat(file) then
+    local text = { "---", "BasedOnStyle: LLVM", "IndentWidth: 4" }
+    vim.fn.writefile(text, file)
+end
+
 return {
     "neovim/nvim-lspconfig",
     config = function()


### PR DESCRIPTION
This should have been part of the config a long time ago