### PR TITLE
Use `luasnip` instead of `vim.snippet`

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,9 +1,11 @@
 {
+  "LuaSnip": { "branch": "master", "commit": "33b06d72d220aa56a7ce80a0dd6f06c70cd82b9d" },
   "cmp-nvim-lsp": { "branch": "main", "commit": "39e2eda76828d88b773cc27a3f61d2ad782c922d" },
+  "cmp_luasnip": { "branch": "master", "commit": "98d9cb5c2c38532bd9bdb481067b20fea8f32e90" },
   "gruvbox.nvim": { "branch": "main", "commit": "7a1b23e4edf73a39642e77508ee6b9cbb8c60f9e" },
   "lazy.nvim": { "branch": "main", "commit": "077102c5bfc578693f12377846d427f49bc50076" },
   "nvim-autopairs": { "branch": "master", "commit": "e38c5d837e755ce186ae51d2c48e1b387c4425c6" },
-  "nvim-cmp": { "branch": "main", "commit": "ae644feb7b67bf1ce4260c231d1d4300b19c6f30" },
+  "nvim-cmp": { "branch": "main", "commit": "ca4d3330d386e76967e53b85953c170658255ecb" },
   "nvim-lspconfig": { "branch": "master", "commit": "e9b1c95d29ca9e479fc39896b31d24eed96b40a3" },
   "nvim-treesitter": { "branch": "master", "commit": "d13f0183ba93f9b5aba7359146f294abfffff9c3" },
   "plenary.nvim": { "branch": "master", "commit": "a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683" },

--- a/lua/plugins/completion.lua
+++ b/lua/plugins/completion.lua
@@ -1,10 +1,13 @@
 return {
     "hrsh7th/nvim-cmp",
     dependencies = {
+        "L3MON4D3/LuaSnip",
         "hrsh7th/cmp-nvim-lsp",
+        "saadparwaiz1/cmp_luasnip",
     },
     config = function()
         -- variables
+        local luasnip = require("luasnip")
         local cmp_autopairs = require("nvim-autopairs.completion.cmp")
         local cmp = require("cmp")
 
@@ -35,6 +38,11 @@ return {
                     return vim_item
                 end
             },
+            snippet = {
+                expand = function(args)
+                    luasnip.lsp_expand(args.body)
+                end,
+            },
             mapping = cmp.mapping.preset.insert({
                 ["<C-Space>"] = cmp.mapping.complete(),
                 ["<CR>"] = cmp.mapping.confirm({
@@ -42,15 +50,15 @@ return {
                     select = true,
                 }),
                 ["<Tab>"] = cmp.mapping(function(fallback)
-                    if vim.snippet.active({ direction = 1 }) then
-                        vim.snippet.jump(1)
+                    if luasnip.expand_or_jumpable() then
+                        luasnip.expand_or_jump()
                     else
                         fallback()
                     end
                 end, { "i", "s" }),
                 ["<S-Tab>"] = cmp.mapping(function(fallback)
-                    if vim.snippet.active({ direction = -1 }) then
-                        vim.snippet.jump(-1)
+                    if luasnip.jumpable(-1) then
+                        luasnip.jump(-1)
                     else
                         fallback()
                     end


### PR DESCRIPTION
This pull request includes updates to the `lua/plugins/completion.lua` file and the `lazy-lock.json` file to add LuaSnip support and update plugin versions.

### Plugin additions and updates:

* Added `LuaSnip` and `cmp_luasnip` as dependencies in `lua/plugins/completion.lua` and updated `lazy-lock.json` to include these plugins. [[1]](diffhunk://#diff-a046c2bf8809cb128a30adf1b7db2846ae17bc5351f1d30191ef844bb3f13fe0R4-R10) [[2]](diffhunk://#diff-38c3069a80837a83b8298c8f4f35d135960a5fb36eaa5bd33e1c71cae4b86379R2-R8)
* Updated the commit hash for `nvim-cmp` in `lazy-lock.json` to the latest version.

### Configuration changes:

* Integrated `LuaSnip` into the completion configuration, including the snippet expansion function and updated key mappings for snippet navigation in `lua/plugins/completion.lua`.