### PR TITLE
Check for lsp binary before setting it up

### DIFF
--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -10,13 +10,24 @@ return {
             signs = false
         })
 
+        -- setup the lsp only if it is available
+        local function setup_lsp(lsp, config)
+            local cmd = lspconfig[lsp].document_config.default_config.cmd[1]
+            if vim.fn.executable(cmd) == 1 then
+                lspconfig[lsp].setup(config)
+            end
+        end
+
+        -- lsp table
+        local lsp = {}
+
         -- bash
-        lspconfig.bashls.setup({
+        lsp.bashls = {
             capabilities = capabilities,
-        })
+        }
 
         -- clangd
-        lspconfig.clangd.setup({
+        lsp.clangd = {
             capabilities = capabilities,
             on_init = function(client)
                 local request = client.rpc.request
@@ -43,20 +54,20 @@ return {
                     return request(method, params, new_handler, ...)
                 end
             end,
-        })
+        }
 
         -- haskell
-        lspconfig.hls.setup({
+        lsp.hls = {
             capabilities = capabilities,
             settings = {
                 haskell = {
                     formattingProvider = "fourmolu"
                 }
             }
-        })
+        }
 
         -- lua
-        lspconfig.lua_ls.setup({
+        lsp.lua_ls = {
             capabilities = capabilities,
             on_init = function(client)
                 local path = client.workspace_folders[1].name
@@ -85,10 +96,10 @@ return {
             settings = {
                 Lua = {}
             }
-        })
+        }
 
         -- rust
-        lspconfig.rust_analyzer.setup({
+        lsp.rust_analyzer = {
             capabilities = capabilities,
             settings = {
                 ["rust-analyzer"] = {
@@ -100,6 +111,11 @@ return {
                     }
                 }
             }
-        })
+        }
+
+        -- call the setup lsp function for every lsp
+        for lsp_name, config in pairs(lsp) do
+            setup_lsp(lsp_name, config)
+        end
     end,
 }


### PR DESCRIPTION
This pull request includes changes to the `lua/plugins/lspconfig.lua` file to improve the setup process for various language servers. The main update involves adding a helper function to conditionally set up language servers only if they are available on the system.

Enhancements to LSP setup:

* Added `setup_lsp` function to check if the language server executable is available before setting it up.
* Refactored the configuration of language servers (`bashls`, `clangd`, `hls`, `lua_ls`, `rust_analyzer`) into a table for easier management. [[1]](diffhunk://#diff-1c07a3d54fe622b42a928a7deaec94bd311a8ea55cc6a03559856469eef087e7R13-R30) [[2]](diffhunk://#diff-1c07a3d54fe622b42a928a7deaec94bd311a8ea55cc6a03559856469eef087e7L46-R70) [[3]](diffhunk://#diff-1c07a3d54fe622b42a928a7deaec94bd311a8ea55cc6a03559856469eef087e7L88-R102) [[4]](diffhunk://#diff-1c07a3d54fe622b42a928a7deaec94bd311a8ea55cc6a03559856469eef087e7L103-R119)
* Iterated over the language server table to call the `setup_lsp` function for each server.